### PR TITLE
➕ Add practice backend process

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -30,3 +30,8 @@ check_answer:
     methods: POST
     path: /check_answer
     controller: App\Infrastructure\Controller\Word\CheckAnswerController::checkAnswer
+
+practice:
+    methods: POST
+    path: /practice
+    controller: App\Infrastructure\Controller\Category\PracticeController::practice

--- a/src/Application/UseCase/Category/CreateCategoryUseCase/CreateCategoryUseCase.php
+++ b/src/Application/UseCase/Category/CreateCategoryUseCase/CreateCategoryUseCase.php
@@ -2,7 +2,7 @@
 
 namespace App\Application\UseCase\Category\CreateCategoryUseCase;
 
-use App\Domain\Services\Category\CategoryCreator\CategoryCreator;
+use App\Domain\Services\Category\CategoryCreator;
 
 class CreateCategoryUseCase
 {

--- a/src/Application/UseCase/Category/PracticeUseCase/PracticeRequest.php
+++ b/src/Application/UseCase/Category/PracticeUseCase/PracticeRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Application\UseCase\Category\PracticeUseCase;
+
+class PracticeRequest
+{
+    private $categoryId;
+
+    public function __construct(?int $categoryId)
+    {
+        $this->categoryId = $categoryId;
+    }
+
+    public function getCategoryId(): ?int
+    {
+        return $this->categoryId;
+    }
+}

--- a/src/Application/UseCase/Category/PracticeUseCase/PracticeResponse.php
+++ b/src/Application/UseCase/Category/PracticeUseCase/PracticeResponse.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Application\UseCase\Category\PracticeUseCase;
+
+use App\Application\UseCase\GenericResponse;
+
+class PracticeResponse extends GenericResponse
+{
+    public function __construct(string $message, int $code)
+    {
+        parent::__construct($message, $code);
+    }
+}

--- a/src/Application/UseCase/Category/PracticeUseCase/PracticeUseCase.php
+++ b/src/Application/UseCase/Category/PracticeUseCase/PracticeUseCase.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Application\UseCase\Category\PracticeUseCase;
+
+use App\Domain\Services\Category\AnswerDatesUpdater;
+
+class PracticeUseCase
+{
+    private $answerDatesUpdater;
+
+    public function __construct(AnswerDatesUpdater $answerDatesUpdater)
+    {
+        $this->answerDatesUpdater = $answerDatesUpdater;
+    }
+
+    public function execute(PracticeRequest $practiceRequest)
+    {
+        $success = $this->answerDatesUpdater->update($practiceRequest->getCategoryId());
+        if (!$success) {
+            return new PracticeResponse(
+                'There was an error while trying to update the answer dates',
+                PracticeResponse::GENERIC_ERROR
+            );
+        }
+
+        return new PracticeResponse(
+            'Answer dates updated successfully',
+            PracticeResponse::SUCCESSFUL_REQUEST
+        );
+    }
+}

--- a/src/Domain/Services/Category/AnswerDatesUpdater.php
+++ b/src/Domain/Services/Category/AnswerDatesUpdater.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Domain\Services\Category;
+
+use App\Domain\Repository\CategoryRepository;
+use App\Domain\Services\User\UserGetter;
+use Doctrine\ORM\EntityManagerInterface;
+
+class AnswerDatesUpdater
+{
+    private $categoryRepository;
+    private $userGetter;
+    private $entityManager;
+
+    public function __construct(
+        CategoryRepository $categoryRepository,
+        UserGetter $userGetter,
+        EntityManagerInterface $entityManager)
+    {
+        $this->categoryRepository = $categoryRepository;
+        $this->userGetter = $userGetter;
+        $this->entityManager = $entityManager;
+    }
+
+    public function update(?int $categoryId): bool
+    {
+        $user = $this->userGetter->getUser();
+        $category = $this->categoryRepository->findOneBy(['id' => $categoryId, 'user' => $user]);
+
+        if (!$category) {
+            return false;
+        }
+
+        foreach ($category->getWords() as $word) {
+            $word->setAnswerDate(new \DateTime('yesterday'));
+        }
+
+        try {
+            $this->entityManager->persist($category);
+            $this->entityManager->flush();
+        } catch (\Exception $e) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Domain/Services/Category/CategoryCreator.php
+++ b/src/Domain/Services/Category/CategoryCreator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Domain\Services\Category\CategoryCreator;
+namespace App\Domain\Services\Category;
 
 use App\Domain\Entity\Category;
 use App\Domain\Services\User\UserGetter;

--- a/src/Domain/Services/Word/AnswerChecker.php
+++ b/src/Domain/Services/Word/AnswerChecker.php
@@ -3,20 +3,31 @@
 namespace App\Domain\Services\Word;
 
 use App\Domain\Repository\WordRepository;
+use Doctrine\ORM\EntityManagerInterface;
 
 class AnswerChecker
 {
     private $wordRepository;
+    private $entityManager;
 
-    public function __construct(WordRepository $wordRepository)
+    public function __construct(WordRepository $wordRepository, EntityManagerInterface $entityManager)
     {
         $this->wordRepository = $wordRepository;
+        $this->entityManager = $entityManager;
     }
 
     public function check(int $wordId, string $answer): bool
     {
         $word = $this->wordRepository->find($wordId);
+        if (strtolower($word->getTranslation()) != strtolower($answer)) {
+            return false;
+        }
 
-        return strtolower($word->getTranslation()) == strtolower($answer);
+        $word->setAnswerDate(new \DateTime('now'));
+
+        $this->entityManager->persist($word);
+        $this->entityManager->flush();
+
+        return true;
     }
 }

--- a/src/Infrastructure/Controller/Category/PracticeController.php
+++ b/src/Infrastructure/Controller/Category/PracticeController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Infrastructure\Controller\Category;
+
+use App\Application\UseCase\Category\PracticeUseCase\PracticeRequest;
+use App\Application\UseCase\Category\PracticeUseCase\PracticeUseCase;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+
+class PracticeController extends AbstractController
+{
+    public function practice(Request $request, PracticeUseCase $practiceUseCase)
+    {
+        $categoryId = $request->get('categoryId');
+
+        $practiceRequest = new PracticeRequest($categoryId);
+        $practiceResponse = $practiceUseCase->execute($practiceRequest);
+
+        $error = $practiceResponse->getCode();
+
+        if ($error) {
+            $this->addFlash('danger', 'There was an error while trying to start the practice. Please, try again.');
+        }
+
+        return $this->redirectToRoute('home');
+    }
+}


### PR DESCRIPTION
# Done
Users will have the option of practicing the words of a category at any time just pressing a button. Internally, this process will put the date of the answers to the previous day at 00:00:00. As the words can be answered after 12h this will enable all the words of the category to be responded.

# Tests
Parameters | Response | It Works
--|--|--
categoryId (belonging to the current user) | 0 (nice) | ✅ 
categoryId (doesn't belong to the current user) | 1 (error) | ✅ 

## Refactors
- The service that checked if an answer was correct was not saving the time when the user made it. It's been fixed.
- The service that creates a category has been moved to an upper directory so it's in the same level as all other services.